### PR TITLE
A toolbar display when switching to fragment_details

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,6 @@
     <option name="filePathToZoomLevelMap">
       <map>
         <entry key="..\:/Users/user/Loovie/app/src/main/res/drawable/corner_button_background.xml" value="0.251" />
-        <entry key="..\:/Users/user/Loovie/app/src/main/res/drawable/ic_baseline_home.xml" value="0.235" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/drawable/ic_baseline_menu_24.xml" value="0.2365" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/drawable/ic_baseline_settings_24.xml" value="0.2365" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/drawable/ic_baseline_share_24.xml" value="0.235" />
@@ -12,8 +11,7 @@
         <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/activity_details.xml" value="0.25416666666666665" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/activity_main.xml" value="0.24010416666666667" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/film_item.xml" value="0.25416666666666665" />
-        <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/fragment_details.xml" value="0.19202898550724637" />
-        <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/fragment_home.xml" value="0.25416666666666665" />
+        <entry key="..\:/Users/user/Loovie/app/src/main/res/layout/fragment_details.xml" value="0.25416666666666665" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/menu/navigation_menu.xml" value="0.25416666666666665" />
         <entry key="..\:/Users/user/Loovie/app/src/main/res/menu/top_toolbar.xml" value="0.25416666666666665" />
       </map>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,9 @@ android {
 
 dependencies {
 
+    def coordinatorLayoutVersion = "1.2.0"
+    implementation "androidx.coordinatorlayout:coordinatorlayout:$coordinatorLayoutVersion"
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'

--- a/app/src/main/java/com/amirovdev/loovie/DetailsFragment.kt
+++ b/app/src/main/java/com/amirovdev/loovie/DetailsFragment.kt
@@ -1,5 +1,6 @@
 package com.amirovdev.loovie
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.fragment.app.Fragment
 import com.amirovdev.loovie.model.Film
+import kotlinx.android.synthetic.main.fragment_details.*
 
 /**
  * A screen for film details: when the user clicks
@@ -17,10 +19,12 @@ import com.amirovdev.loovie.model.Film
 
 class DetailsFragment : Fragment() {
 
+    // in this method we get View, so we should initialize all the Views in here
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         processViews()
+        println("--------------------------\n${details_toolbar.isOverflowMenuShowing}\n------------------------------------")
     }
 
     override fun onCreateView(

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -10,25 +10,24 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
+    android:fitsSystemWindows="false"
     tools:context=".DetailsFragment">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="200dp"
-        android:fitsSystemWindows="false"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:fitsSystemWindows="true"
+        android:theme="@style/Theme.Loovie">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/toolbar_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true"
-            android:minHeight="60dp"
             app:contentScrim="?attr/colorPrimary"
             app:layout_scrollFlags="scroll|exitUntilCollapsed"
-            app:toolbarId="@+id/toolbar">
+            app:toolbarId="@id/details_toolbar">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/details_poster"
@@ -45,7 +44,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"
-                app:popupTheme="@style/Theme.Loovie"/>
+                app:popupTheme="@style/Theme.Loovie" />
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
 


### PR DESCRIPTION
bug fix: when switching to details.fragment, AppBarLayout remains, plus when scrolling down a toolbar from CoordinatorLayout appears